### PR TITLE
feat: Add ability to specify or change an events color

### DIFF
--- a/lib/rcal/adapters/calendar/google.rb
+++ b/lib/rcal/adapters/calendar/google.rb
@@ -93,7 +93,8 @@ module Rcal
             recurring_event_id: google_event.recurring_event_id,
             response_status: extract_self_response_status(google_event.attendees),
             attendees: build_attendees(google_event.attendees),
-            timezone: google_event.start&.time_zone
+            timezone: google_event.start&.time_zone,
+            color_id: google_event.color_id
           )
         end
 
@@ -134,7 +135,8 @@ module Rcal
           google_event = ::Google::Apis::CalendarV3::Event.new(
             summary: event.summary,
             description: event.description,
-            location: event.location
+            location: event.location,
+            color_id: event.color_id
           )
 
           if event.all_day?

--- a/lib/rcal/color_map.rb
+++ b/lib/rcal/color_map.rb
@@ -1,0 +1,40 @@
+module Rcal
+  module ColorMap
+    COLORS = {
+      "lavender" => "1",
+      "sage" => "2",
+      "grape" => "3",
+      "flamingo" => "4",
+      "banana" => "5",
+      "tangerine" => "6",
+      "peacock" => "7",
+      "graphite" => "8",
+      "blueberry" => "9",
+      "basil" => "10",
+      "tomato" => "11"
+    }.freeze
+
+    IDS = COLORS.values.freeze
+
+    class << self
+      # Resolves a color name or numeric ID to a Google Calendar color ID string.
+      # Accepts names ("tomato"), IDs ("11"), or IDs as integers (11).
+      # Raises Rcal::Error for invalid input.
+      def resolve(input)
+        normalized = input.to_s.strip.downcase
+
+        # Try as a name first
+        return COLORS[normalized] if COLORS.key?(normalized)
+
+        # Try as a numeric ID
+        return normalized if IDS.include?(normalized)
+
+        raise Rcal::Error, "Unknown color: #{input}. Run 'rcal colors' to see available colors."
+      end
+
+      def all
+        COLORS
+      end
+    end
+  end
+end

--- a/lib/rcal/commands.rb
+++ b/lib/rcal/commands.rb
@@ -11,6 +11,7 @@ module Rcal
 
     register :Add, "add", "rcal/commands/add"
     register :Agenda, "agenda", "rcal/commands/agenda"
+    register :Colors, "colors", "rcal/commands/colors"
     register :Edit, "edit", "rcal/commands/edit"
     register :Help, "help", "rcal/commands/help"
     register :Import, "import", "rcal/commands/import"

--- a/lib/rcal/commands/add.rb
+++ b/lib/rcal/commands/add.rb
@@ -5,6 +5,7 @@ require_relative "../date_parser"
 require_relative "../duration_parser"
 require_relative "../models/event"
 require_relative "../presenters/event_presenter"
+require_relative "../color_map"
 
 module Rcal
   module Commands
@@ -26,12 +27,14 @@ module Rcal
             --location=TEXT     Event location
             --description=TEXT  Event description
             --calendar=ID       Calendar to add event to (default: primary)
+            --color=COLOR       Event color (name or ID). Run 'rcal colors' to see options
             --all-day           Create an all-day event
 
           Examples:
             rcal add --title="Team Meeting" --when="tomorrow 3pm"
             rcal add --title="Lunch" --when="friday noon" --duration=1h --location="Cafe"
             rcal add --title="Vacation" --when="monday" --all-day
+            rcal add --title="Important" --when="tomorrow 9am" --color=tomato
         HELP
       end
 
@@ -53,7 +56,7 @@ module Rcal
 
       private
 
-      VALUE_OPTIONS = %w[title when duration location description calendar].freeze
+      VALUE_OPTIONS = %w[title when duration location description calendar color].freeze
       FLAG_OPTIONS = {"all-day" => :all_day}.freeze
 
       def parse_options(args)
@@ -104,7 +107,8 @@ module Rcal
           end_time: end_time,
           location: options[:location],
           description: options[:description],
-          all_day: options[:all_day]
+          all_day: options[:all_day],
+          color_id: resolve_color(options[:color])
         )
       end
 
@@ -129,6 +133,14 @@ module Rcal
         else
           start_time + duration
         end
+      end
+
+      def resolve_color(color_input)
+        return nil if color_input.nil?
+
+        ColorMap.resolve(color_input)
+      rescue Rcal::Error => e
+        raise CLI::Kit::Abort, e.message
       end
 
       def display_created_event(event)

--- a/lib/rcal/commands/colors.rb
+++ b/lib/rcal/commands/colors.rb
@@ -1,0 +1,34 @@
+require "rcal"
+require_relative "../color_map"
+
+module Rcal
+  module Commands
+    class Colors < Rcal::Command
+      def self.help
+        <<~HELP
+          List available event colors.
+
+          Usage: rcal colors
+
+          Shows the color names and IDs that can be used with the --color option
+          on the 'add' and 'edit' commands.
+
+          Examples:
+            rcal colors
+            rcal add --title="Meeting" --when="tomorrow 3pm" --color=tomato
+            rcal edit abc123 --color=peacock
+        HELP
+      end
+
+      def run(_args, _name)
+        puts "Available event colors:\n\n"
+
+        ColorMap.all.each do |name, id|
+          puts "  #{id.rjust(2)}  #{name}"
+        end
+
+        puts "\nUsage: rcal add --color=NAME or rcal add --color=ID"
+      end
+    end
+  end
+end

--- a/lib/rcal/commands/edit.rb
+++ b/lib/rcal/commands/edit.rb
@@ -5,6 +5,7 @@ require_relative "../date_parser"
 require_relative "../duration_parser"
 require_relative "../models/event"
 require_relative "../presenters/event_presenter"
+require_relative "../color_map"
 
 module Rcal
   module Commands
@@ -25,11 +26,13 @@ module Rcal
             --location=TEXT     New event location
             --description=TEXT  New event description
             --calendar=ID       Calendar containing the event (default: primary)
+            --color=COLOR       New event color (name or ID). Run 'rcal colors' to see options
 
           Examples:
             rcal edit abc123 --title="Updated Meeting"
             rcal edit abc123 --when="tomorrow 4pm" --duration=30m
             rcal edit abc123 --location="Room 202" --calendar=work@company.com
+            rcal edit abc123 --color=peacock
         HELP
       end
 
@@ -55,7 +58,7 @@ module Rcal
 
       private
 
-      VALUE_OPTIONS = %w[title when duration location description calendar].freeze
+      VALUE_OPTIONS = %w[title when duration location description calendar color].freeze
 
       def parse_options(args)
         options = {calendar: "primary"}
@@ -101,6 +104,7 @@ module Rcal
         summary = options[:title] || existing_event.summary
         location = options.key?(:location) ? options[:location] : existing_event.location
         description = options.key?(:description) ? options[:description] : existing_event.description
+        color_id = options.key?(:color) ? resolve_color(options[:color]) : existing_event.color_id
 
         start_time = if options[:when]
           parse_start_time(options[:when])
@@ -127,8 +131,17 @@ module Rcal
           location: location,
           description: description,
           all_day: existing_event.all_day?,
-          calendar_id: existing_event.calendar_id
+          calendar_id: existing_event.calendar_id,
+          color_id: color_id
         )
+      end
+
+      def resolve_color(color_input)
+        return nil if color_input.nil?
+
+        ColorMap.resolve(color_input)
+      rescue Rcal::Error => e
+        raise CLI::Kit::Abort, e.message
       end
 
       def parse_start_time(when_text)

--- a/lib/rcal/models/event.rb
+++ b/lib/rcal/models/event.rb
@@ -4,7 +4,8 @@ module Rcal
   class Event
     attr_reader :id, :summary, :start_time, :end_time, :description,
       :location, :calendar_id, :transparency, :recurrence,
-      :recurring_event_id, :response_status, :attendees, :timezone
+      :recurring_event_id, :response_status, :attendees, :timezone,
+      :color_id
 
     def initialize(
       summary:,
@@ -20,7 +21,8 @@ module Rcal
       recurring_event_id: nil,
       response_status: nil,
       attendees: nil,
-      timezone: nil
+      timezone: nil,
+      color_id: nil
     )
       @id = id
       @summary = summary
@@ -36,6 +38,7 @@ module Rcal
       @response_status = response_status
       @attendees = normalize_attendees(attendees)
       @timezone = timezone
+      @color_id = color_id
     end
 
     def all_day?

--- a/test/unit/adapters/calendar/google_test.rb
+++ b/test/unit/adapters/calendar/google_test.rb
@@ -163,6 +163,66 @@ module Rcal
           assert_equal "Vacation", event.summary
         end
 
+        def test_list_events_all_day_event_has_correct_time_values
+          google_response = stub_events_response([
+            {
+              id: "allday1",
+              summary: "Vacation",
+              start: {date: "2024-01-15"},
+              end: {date: "2024-01-16"}
+            }
+          ])
+
+          @mock_service.expects(:list_events).returns(google_response)
+
+          event = @adapter.list_events(
+            calendar_id: "primary",
+            time_min: Time.new(2024, 1, 14),
+            time_max: Time.new(2024, 1, 17)
+          ).first
+
+          assert_instance_of Time, event.start_time
+          assert_instance_of Time, event.end_time
+          assert_equal Date.new(2024, 1, 15), event.start_time.to_date
+          assert_equal Date.new(2024, 1, 16), event.end_time.to_date
+        end
+
+        def test_list_events_handles_mixed_timed_and_all_day_events
+          google_response = stub_events_response([
+            {
+              id: "allday1",
+              summary: "Company Holiday",
+              start: {date: "2024-01-15"},
+              end: {date: "2024-01-16"}
+            },
+            {
+              id: "timed1",
+              summary: "Morning Standup",
+              start: {date_time: "2024-01-15T09:00:00-05:00", time_zone: "America/New_York"},
+              end: {date_time: "2024-01-15T09:30:00-05:00", time_zone: "America/New_York"}
+            }
+          ])
+
+          @mock_service.expects(:list_events).returns(google_response)
+
+          events = @adapter.list_events(
+            calendar_id: "primary",
+            time_min: Time.new(2024, 1, 14),
+            time_max: Time.new(2024, 1, 17)
+          )
+
+          assert_equal 2, events.length
+
+          all_day_event = events.find { |e| e.id == "allday1" }
+          timed_event = events.find { |e| e.id == "timed1" }
+
+          assert all_day_event.all_day?
+          refute timed_event.all_day?
+
+          assert_instance_of Time, all_day_event.start_time
+          assert_instance_of Time, timed_event.start_time
+        end
+
         def test_list_events_extracts_self_response_status
           google_response = stub_events_response([
             {
@@ -491,6 +551,121 @@ module Rcal
           )
         end
 
+        # Color ID tests
+
+        def test_list_events_maps_color_id
+          google_response = stub_events_response([
+            {
+              id: "event1",
+              summary: "Important Meeting",
+              start: {date_time: Time.new(2024, 1, 15, 10, 0, 0).iso8601},
+              end: {date_time: Time.new(2024, 1, 15, 11, 0, 0).iso8601},
+              color_id: "11"
+            }
+          ])
+
+          @mock_service.expects(:list_events).returns(google_response)
+
+          event = @adapter.list_events(
+            calendar_id: "primary",
+            time_min: Time.new(2024, 1, 14),
+            time_max: Time.new(2024, 1, 17)
+          ).first
+
+          assert_equal "11", event.color_id
+        end
+
+        def test_list_events_color_id_nil_when_unset
+          google_response = stub_events_response([
+            {
+              id: "event1",
+              summary: "Plain Meeting",
+              start: {date_time: Time.new(2024, 1, 15, 10, 0, 0).iso8601},
+              end: {date_time: Time.new(2024, 1, 15, 11, 0, 0).iso8601}
+            }
+          ])
+
+          @mock_service.expects(:list_events).returns(google_response)
+
+          event = @adapter.list_events(
+            calendar_id: "primary",
+            time_min: Time.new(2024, 1, 14),
+            time_max: Time.new(2024, 1, 17)
+          ).first
+
+          assert_nil event.color_id
+        end
+
+        def test_create_event_sets_color_id
+          input_event = Rcal::Event.new(
+            summary: "Important Meeting",
+            start_time: Time.new(2024, 1, 15, 10, 0, 0),
+            end_time: Time.new(2024, 1, 15, 11, 0, 0),
+            color_id: "11"
+          )
+
+          created_event = stub_single_event(
+            id: "new1",
+            summary: "Important Meeting",
+            color_id: "11"
+          )
+
+          @mock_service.expects(:insert_event).with("primary", anything) do |_cal_id, google_event|
+            assert_equal "11", google_event.color_id
+            true
+          end.returns(created_event)
+
+          result = @adapter.create_event(calendar_id: "primary", event: input_event)
+
+          assert_equal "11", result.color_id
+        end
+
+        def test_create_event_omits_color_id_when_nil
+          input_event = Rcal::Event.new(
+            summary: "Plain Meeting",
+            start_time: Time.new(2024, 1, 15, 10, 0, 0),
+            end_time: Time.new(2024, 1, 15, 11, 0, 0)
+          )
+
+          created_event = stub_single_event(id: "new1", summary: "Plain Meeting")
+
+          @mock_service.expects(:insert_event).with("primary", anything) do |_cal_id, google_event|
+            assert_nil google_event.color_id
+            true
+          end.returns(created_event)
+
+          @adapter.create_event(calendar_id: "primary", event: input_event)
+        end
+
+        def test_update_event_sets_color_id
+          input_event = Rcal::Event.new(
+            id: "existing123",
+            summary: "Meeting",
+            start_time: Time.new(2024, 1, 15, 10, 0, 0),
+            end_time: Time.new(2024, 1, 15, 11, 0, 0),
+            color_id: "7"
+          )
+
+          updated_event = stub_single_event(
+            id: "existing123",
+            summary: "Meeting",
+            color_id: "7"
+          )
+
+          @mock_service.expects(:update_event).with("primary", "existing123", anything) do |_cal, _id, google_event|
+            assert_equal "7", google_event.color_id
+            true
+          end.returns(updated_event)
+
+          result = @adapter.update_event(
+            calendar_id: "primary",
+            event_id: "existing123",
+            event: input_event
+          )
+
+          assert_equal "7", result.color_id
+        end
+
         private
 
         def stub_calendar_list_response(calendars)
@@ -512,6 +687,39 @@ module Rcal
           response
         end
 
+        # Converts a date string to a Date object to match the Google API gem's
+        # deserialization behavior (property :date, type: Date).
+        def coerce_date(value)
+          value.is_a?(String) ? Date.parse(value) : value
+        end
+
+        def stub_event_time_obj(name, data)
+          obj = mock(name)
+          if data
+            obj.stubs(:date_time).returns(data[:date_time] ? Time.parse(data[:date_time]) : nil)
+            obj.stubs(:date).returns(data[:date] ? coerce_date(data[:date]) : nil)
+            obj.stubs(:time_zone).returns(data[:time_zone])
+          else
+            obj.stubs(:date_time).returns(Time.now)
+            obj.stubs(:date).returns(nil)
+            obj.stubs(:time_zone).returns(nil)
+          end
+          obj
+        end
+
+        def stub_attendees(attendees)
+          return nil if attendees.nil?
+
+          attendees.map do |att|
+            att_obj = mock("attendee")
+            att_obj.stubs(:email).returns(att[:email])
+            att_obj.stubs(:response_status).returns(att[:response_status])
+            att_obj.stubs(:self).returns(att[:self])
+            att_obj.stubs(:resource).returns(att[:resource])
+            att_obj
+          end
+        end
+
         def stub_single_event(
           id:,
           summary:,
@@ -522,8 +730,11 @@ module Rcal
           transparency: nil,
           recurrence: nil,
           recurring_event_id: nil,
-          attendees: nil
+          attendees: nil,
+          color_id: nil
         )
+          end_data = binding.local_variable_get(:end)
+
           item = mock("event_entry_#{id}")
           item.stubs(:id).returns(id)
           item.stubs(:summary).returns(summary)
@@ -532,48 +743,14 @@ module Rcal
           item.stubs(:transparency).returns(transparency)
           item.stubs(:recurrence).returns(recurrence)
           item.stubs(:recurring_event_id).returns(recurring_event_id)
+          item.stubs(:color_id).returns(color_id)
 
-          # Start time
-          start_obj = mock("start_#{id}")
-          if start
-            start_obj.stubs(:date_time).returns(start[:date_time] ? Time.parse(start[:date_time]) : nil)
-            start_obj.stubs(:date).returns(start[:date])
-            start_obj.stubs(:time_zone).returns(start[:time_zone])
-          else
-            start_obj.stubs(:date_time).returns(Time.now)
-            start_obj.stubs(:date).returns(nil)
-            start_obj.stubs(:time_zone).returns(nil)
-          end
-          item.stubs(:start).returns(start_obj)
+          item.stubs(:start).returns(stub_event_time_obj("start_#{id}", start))
 
-          # End time
-          end_obj = mock("end_#{id}")
-          if binding.local_variable_get(:end)
-            end_data = binding.local_variable_get(:end)
-            end_obj.stubs(:date_time).returns(end_data[:date_time] ? Time.parse(end_data[:date_time]) : nil)
-            end_obj.stubs(:date).returns(end_data[:date])
-            end_obj.stubs(:time_zone).returns(end_data[:time_zone])
-          else
-            end_obj.stubs(:date_time).returns(Time.now + 3600)
-            end_obj.stubs(:date).returns(nil)
-            end_obj.stubs(:time_zone).returns(nil)
-          end
-          item.stubs(:end).returns(end_obj)
+          default_end = start ? nil : {date_time: (Time.now + 3600).iso8601}
+          item.stubs(:end).returns(stub_event_time_obj("end_#{id}", end_data || default_end))
 
-          # Attendees
-          if attendees
-            attendee_objs = attendees.map do |att|
-              att_obj = mock("attendee")
-              att_obj.stubs(:email).returns(att[:email])
-              att_obj.stubs(:response_status).returns(att[:response_status])
-              att_obj.stubs(:self).returns(att[:self])
-              att_obj.stubs(:resource).returns(att[:resource])
-              att_obj
-            end
-            item.stubs(:attendees).returns(attendee_objs)
-          else
-            item.stubs(:attendees).returns(nil)
-          end
+          item.stubs(:attendees).returns(stub_attendees(attendees))
 
           item
         end
@@ -588,47 +765,14 @@ module Rcal
             item.stubs(:transparency).returns(evt[:transparency])
             item.stubs(:recurrence).returns(evt[:recurrence])
             item.stubs(:recurring_event_id).returns(evt[:recurring_event_id])
+            item.stubs(:color_id).returns(evt[:color_id])
 
-            # Start time
-            start_obj = mock("start")
-            if evt[:start]
-              start_obj.stubs(:date_time).returns(evt[:start][:date_time] ? Time.parse(evt[:start][:date_time]) : nil)
-              start_obj.stubs(:date).returns(evt[:start][:date])
-              start_obj.stubs(:time_zone).returns(evt[:start][:time_zone])
-            else
-              start_obj.stubs(:date_time).returns(Time.now)
-              start_obj.stubs(:date).returns(nil)
-              start_obj.stubs(:time_zone).returns(nil)
-            end
-            item.stubs(:start).returns(start_obj)
+            item.stubs(:start).returns(stub_event_time_obj("start", evt[:start]))
 
-            # End time
-            end_obj = mock("end")
-            if evt[:end]
-              end_obj.stubs(:date_time).returns(evt[:end][:date_time] ? Time.parse(evt[:end][:date_time]) : nil)
-              end_obj.stubs(:date).returns(evt[:end][:date])
-              end_obj.stubs(:time_zone).returns(evt[:end][:time_zone])
-            else
-              end_obj.stubs(:date_time).returns(Time.now + 3600)
-              end_obj.stubs(:date).returns(nil)
-              end_obj.stubs(:time_zone).returns(nil)
-            end
-            item.stubs(:end).returns(end_obj)
+            default_end = evt[:start] ? nil : {date_time: (Time.now + 3600).iso8601}
+            item.stubs(:end).returns(stub_event_time_obj("end", evt[:end] || default_end))
 
-            # Attendees
-            if evt[:attendees]
-              attendee_objs = evt[:attendees].map do |att|
-                att_obj = mock("attendee")
-                att_obj.stubs(:email).returns(att[:email])
-                att_obj.stubs(:response_status).returns(att[:response_status])
-                att_obj.stubs(:self).returns(att[:self])
-                att_obj.stubs(:resource).returns(att[:resource])
-                att_obj
-              end
-              item.stubs(:attendees).returns(attendee_objs)
-            else
-              item.stubs(:attendees).returns(nil)
-            end
+            item.stubs(:attendees).returns(stub_attendees(evt[:attendees]))
 
             item
           end

--- a/test/unit/color_map_test.rb
+++ b/test/unit/color_map_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+require "rcal/color_map"
+require "rcal/errors"
+
+module Rcal
+  class ColorMapTest < Minitest::Test
+    # Resolution by name
+
+    def test_resolves_color_by_name
+      assert_equal "11", ColorMap.resolve("tomato")
+    end
+
+    def test_resolves_all_color_names
+      expected = {
+        "lavender" => "1", "sage" => "2", "grape" => "3",
+        "flamingo" => "4", "banana" => "5", "tangerine" => "6",
+        "peacock" => "7", "graphite" => "8", "blueberry" => "9",
+        "basil" => "10", "tomato" => "11"
+      }
+
+      expected.each do |name, id|
+        assert_equal id, ColorMap.resolve(name), "Expected #{name} to resolve to #{id}"
+      end
+    end
+
+    def test_resolves_case_insensitively
+      assert_equal "11", ColorMap.resolve("Tomato")
+      assert_equal "11", ColorMap.resolve("TOMATO")
+      assert_equal "7", ColorMap.resolve("Peacock")
+    end
+
+    def test_resolves_with_surrounding_whitespace
+      assert_equal "11", ColorMap.resolve("  tomato  ")
+    end
+
+    # Resolution by ID
+
+    def test_resolves_by_numeric_id_string
+      assert_equal "1", ColorMap.resolve("1")
+      assert_equal "11", ColorMap.resolve("11")
+    end
+
+    def test_resolves_by_integer_id
+      assert_equal "1", ColorMap.resolve(1)
+      assert_equal "11", ColorMap.resolve(11)
+    end
+
+    # Invalid input
+
+    def test_raises_for_unknown_color_name
+      error = assert_raises(Rcal::Error) do
+        ColorMap.resolve("magenta")
+      end
+
+      assert_match(/unknown color/i, error.message)
+      assert_includes error.message, "magenta"
+    end
+
+    def test_raises_for_out_of_range_id
+      error = assert_raises(Rcal::Error) do
+        ColorMap.resolve("12")
+      end
+
+      assert_match(/unknown color/i, error.message)
+    end
+
+    def test_raises_for_zero_id
+      assert_raises(Rcal::Error) do
+        ColorMap.resolve("0")
+      end
+    end
+
+    def test_raises_for_negative_id
+      assert_raises(Rcal::Error) do
+        ColorMap.resolve("-1")
+      end
+    end
+
+    # Listing
+
+    def test_all_returns_complete_mapping
+      all = ColorMap.all
+
+      assert_equal 11, all.length
+      assert_equal "1", all["lavender"]
+      assert_equal "11", all["tomato"]
+    end
+
+    def test_all_returns_frozen_hash
+      assert ColorMap.all.frozen?
+    end
+  end
+end

--- a/test/unit/commands/add_test.rb
+++ b/test/unit/commands/add_test.rb
@@ -203,6 +203,72 @@ module Rcal
         ], "add")
       end
 
+      # Color option tests
+
+      def test_accepts_color_by_name
+        created_event = build_event(id: "new1", summary: "Important")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:create_event).with { |args|
+          args[:event].color_id == "11"
+        }.returns(created_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Add.new
+        cmd.call([
+          "--title=Important",
+          "--when=tomorrow 3pm",
+          "--color=tomato"
+        ], "add")
+      end
+
+      def test_accepts_color_by_id
+        created_event = build_event(id: "new1", summary: "Meeting")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:create_event).with { |args|
+          args[:event].color_id == "7"
+        }.returns(created_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Add.new
+        cmd.call([
+          "--title=Meeting",
+          "--when=tomorrow 3pm",
+          "--color=7"
+        ], "add")
+      end
+
+      def test_color_defaults_to_nil
+        created_event = build_event(id: "new1", summary: "Meeting")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:create_event).with { |args|
+          args[:event].color_id.nil?
+        }.returns(created_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Add.new
+        cmd.call([
+          "--title=Meeting",
+          "--when=tomorrow 3pm"
+        ], "add")
+      end
+
+      def test_rejects_invalid_color
+        cmd = Add.new
+
+        error = assert_raises(CLI::Kit::Abort) do
+          cmd.call([
+            "--title=Meeting",
+            "--when=tomorrow 3pm",
+            "--color=magenta"
+          ], "add")
+        end
+
+        assert_match(/unknown color/i, error.message)
+      end
+
       # Output tests
 
       def test_displays_created_event

--- a/test/unit/commands/agenda_test.rb
+++ b/test/unit/commands/agenda_test.rb
@@ -193,18 +193,79 @@ module Rcal
 
       # Days flag tests
 
-      def test_days_flag_extends_date_range
+      def test_days_flag_passes_correct_date_range_to_adapter
         mock_adapter = mock("calendar_adapter")
 
-        # With --days=7, should fetch a week's worth
-        mock_adapter.expects(:list_events).returns([])
+        expected_time_min = @today.to_time
+        expected_time_max = (@today + 7).to_time
+
+        mock_adapter.expects(:list_events).with(
+          has_entries(
+            calendar_id: "primary",
+            time_min: expected_time_min,
+            time_max: expected_time_max
+          )
+        ).returns([])
+        CalendarService.adapter = mock_adapter
+
+        cmd = Agenda.new
+        cmd.call(["--days=7"], "agenda")
+      end
+
+      def test_days_flag_with_start_date_passes_correct_range
+        mock_adapter = mock("calendar_adapter")
+
+        tomorrow = @today + 1
+        expected_time_min = tomorrow.to_time
+        expected_time_max = (tomorrow + 3).to_time
+
+        mock_adapter.expects(:list_events).with(
+          has_entries(
+            time_min: expected_time_min,
+            time_max: expected_time_max
+          )
+        ).returns([])
+        CalendarService.adapter = mock_adapter
+
+        cmd = Agenda.new
+        cmd.stubs(:parse_date).with("tomorrow").returns(tomorrow)
+        cmd.call(["tomorrow", "--days=3"], "agenda")
+      end
+
+      def test_days_flag_with_all_day_events
+        all_day_event = build_event(
+          summary: "Company Holiday",
+          start_time: today_at(0, 0),
+          all_day: true
+        )
+        timed_event = build_event(
+          summary: "Standup",
+          start_time: today_at(9, 0)
+        )
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:list_events).returns([all_day_event, timed_event])
         CalendarService.adapter = mock_adapter
 
         cmd = Agenda.new
         cmd.call(["--days=7"], "agenda")
 
-        # The command should have calculated a 7-day range
-        # We can verify by checking the formatter received the right data
+        assert_includes captured_output, "Company Holiday"
+        assert_includes captured_output, "Standup"
+      end
+
+      def test_days_flag_shows_empty_days_in_range
+        event = build_event(summary: "Monday Only", start_time: today_at(10, 0))
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:list_events).returns([event])
+        CalendarService.adapter = mock_adapter
+
+        cmd = Agenda.new
+        cmd.call(["--days=3"], "agenda")
+
+        # Should show "No events" for the days without events
+        assert_match(/no events/i, captured_output)
       end
 
       # Authentication tests

--- a/test/unit/commands/colors_test.rb
+++ b/test/unit/commands/colors_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+require "rcal/commands/colors"
+
+module Rcal
+  module Commands
+    class ColorsTest < Minitest::Test
+      def setup
+        @original_stdout = $stdout
+        @output = StringIO.new
+        $stdout = @output
+      end
+
+      def teardown
+        $stdout = @original_stdout
+      end
+
+      def captured_output
+        @output.string
+      end
+
+      def test_lists_all_eleven_colors
+        cmd = Colors.new
+        cmd.call([], "colors")
+
+        ColorMap::COLORS.each do |name, id|
+          assert_includes captured_output, name, "Expected output to include color name '#{name}'"
+          assert_includes captured_output, id, "Expected output to include color ID '#{id}'"
+        end
+      end
+
+      def test_shows_usage_hint
+        cmd = Colors.new
+        cmd.call([], "colors")
+
+        assert_match(/--color/i, captured_output)
+      end
+
+      def test_has_help_text
+        help = Colors.help.to_s
+        assert_match(/colors/i, help)
+        assert_match(/--color/i, help)
+      end
+    end
+  end
+end

--- a/test/unit/commands/edit_test.rb
+++ b/test/unit/commands/edit_test.rb
@@ -171,6 +171,69 @@ module Rcal
         cmd.call(["event123", "--calendar=work@company.com", "--title=Updated"], "edit")
       end
 
+      # Color option tests
+
+      def test_updates_event_color_by_name
+        existing_event = build_event(id: "event123", summary: "Meeting")
+        updated_event = build_event(id: "event123", summary: "Meeting")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:get_event).returns(existing_event)
+        mock_adapter.expects(:update_event).with { |args|
+          args[:event].color_id == "7"
+        }.returns(updated_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Edit.new
+        cmd.call(["event123", "--color=peacock"], "edit")
+      end
+
+      def test_updates_event_color_by_id
+        existing_event = build_event(id: "event123", summary: "Meeting")
+        updated_event = build_event(id: "event123", summary: "Meeting")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:get_event).returns(existing_event)
+        mock_adapter.expects(:update_event).with { |args|
+          args[:event].color_id == "11"
+        }.returns(updated_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Edit.new
+        cmd.call(["event123", "--color=11"], "edit")
+      end
+
+      def test_preserves_existing_color_when_not_specified
+        existing_event = build_event(id: "event123", summary: "Meeting", color_id: "11")
+        updated_event = build_event(id: "event123", summary: "New Title")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:get_event).returns(existing_event)
+        mock_adapter.expects(:update_event).with { |args|
+          args[:event].color_id == "11"
+        }.returns(updated_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Edit.new
+        cmd.call(["event123", "--title=New Title"], "edit")
+      end
+
+      def test_rejects_invalid_color
+        existing_event = build_event(id: "event123", summary: "Meeting")
+
+        mock_adapter = mock("calendar_adapter")
+        mock_adapter.expects(:get_event).returns(existing_event)
+        CalendarService.adapter = mock_adapter
+
+        cmd = Edit.new
+
+        error = assert_raises(CLI::Kit::Abort) do
+          cmd.call(["event123", "--color=magenta"], "edit")
+        end
+
+        assert_match(/unknown color/i, error.message)
+      end
+
       # Error handling tests
 
       def test_handles_event_not_found
@@ -219,7 +282,8 @@ module Rcal
         start_time: nil,
         end_time: nil,
         location: nil,
-        description: nil
+        description: nil,
+        color_id: nil
       )
         start_time ||= Time.now + 3600
         end_time ||= start_time + 3600
@@ -230,7 +294,8 @@ module Rcal
           start_time: start_time,
           end_time: end_time,
           location: location,
-          description: description
+          description: description,
+          color_id: color_id
         )
       end
     end

--- a/test/unit/models/event_test.rb
+++ b/test/unit/models/event_test.rb
@@ -67,6 +67,20 @@ module Rcal
       assert_equal "work@example.com", event.calendar_id
     end
 
+    # Color
+
+    def test_has_color_id
+      event = Event.new(summary: "Meeting", start_time: Time.now, color_id: "11")
+
+      assert_equal "11", event.color_id
+    end
+
+    def test_color_id_defaults_to_nil
+      event = Event.new(summary: "Meeting", start_time: Time.now)
+
+      assert_nil event.color_id
+    end
+
     # All-day events
 
     def test_all_day_defaults_to_false


### PR DESCRIPTION
Google calendars are color coded and new events added to a calendar will take on the calendars default color. However some calendar organization strategies benefit from being able color code certain event. This PR adds the ability to specific an event color when creating or editing an event.